### PR TITLE
Add git filter to remove Jupyter notebook outputs and metadata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb filter=strip-notebook-output

--- a/.gitconfig
+++ b/.gitconfig
@@ -27,3 +27,7 @@
 	all = true
 [help]
 	autocorrect = prompt
+[filter "strip-notebook-output"]
+	clean = "jupyter nbconvert --ClearOutputPreprocessor.enabled=True --ClearMetadataPreprocessor.enabled=True --ClearMetadataPreprocessor.preserve_nb_metadata_mask="language_info" --to=notebook --stdin --stdout --log-level=ERROR"
+	smudge = "cat"
+	required


### PR DESCRIPTION
The `.gitattributes` file must be present in the repository for the filter to be applied.